### PR TITLE
Fix PyPI release CI with cibuildwheel

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -5,32 +5,76 @@ on:
     types: [created]
 
 jobs:
-  deploy:
+  build_sdist:
+    name: Build source distribution
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
 
     defaults:
       run:
         working-directory: wrappers/pyrichdem
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
+        run: pip install build
 
-      - name: Build package
-        run: python -m build
+      - name: Build sdist
+        run: python -m build --sdist
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: wrappers/pyrichdem/dist/*.tar.gz
+
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2
+        with:
+          package-dir: wrappers/pyrichdem
+          output-dir: wheelhouse
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
+
+  publish:
+    name: Publish to PyPI
+    needs: [build_sdist, build_wheels]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist
+
+      - name: Download wheels
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: wrappers/pyrichdem/dist/

--- a/wrappers/pyrichdem/MANIFEST.in
+++ b/wrappers/pyrichdem/MANIFEST.in
@@ -1,4 +1,5 @@
-recursive-include lib *
+recursive-include lib/richdem/include *.h *.hpp
+recursive-include lib/richdem/src *.cpp *.h *.hpp
 recursive-include src *.cpp *.hpp
 include pyproject.toml
 include LICENSE.txt

--- a/wrappers/pyrichdem/pyproject.toml
+++ b/wrappers/pyrichdem/pyproject.toml
@@ -55,3 +55,16 @@ rd_compare = "richdem.cli:RdCompare"
 
 [tool.setuptools.packages.find]
 include = ["richdem*"]
+
+[tool.cibuildwheel]
+build = "cp310-* cp311-* cp312-* cp313-*"
+skip = "*-musllinux_* *-win32 *_i686"
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]
+
+[tool.cibuildwheel.linux]
+archs = ["x86_64"]
+
+[tool.cibuildwheel.windows]
+archs = ["AMD64"]


### PR DESCRIPTION
## Summary
- Fix `MANIFEST.in` recursive symlink loop that caused infinite file copying during sdist build
- Replace single-runner `python -m build` with `cibuildwheel` to produce properly tagged `manylinux`, `macOS`, and `Windows` wheels (PyPI rejects raw `linux_x86_64` wheels)
- Add `[tool.cibuildwheel]` config to `pyproject.toml` targeting CPython 3.10-3.13, skipping musllinux and 32-bit

## Test plan
- [ ] Trigger workflow via a draft release and verify sdist builds without recursion
- [ ] Verify wheels are produced for all 3 platforms (Linux, macOS, Windows)
- [ ] Confirm wheel filenames contain `manylinux`, `macosx`, and `win` platform tags