### PR TITLE
Fix cibuildwheel action version tag

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22
+        uses: pypa/cibuildwheel@v3.3.1
         with:
           package-dir: wrappers/pyrichdem
           output-dir: wheelhouse

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2
+        uses: pypa/cibuildwheel@v2.22
         with:
           package-dir: wrappers/pyrichdem
           output-dir: wheelhouse


### PR DESCRIPTION
## Summary
- Fix `pypa/cibuildwheel@v2` to `pypa/cibuildwheel@v2.22` -- the `v2` tag doesn't exist

## Test plan
- [ ] Verify the CI workflow resolves the action successfully