### PR TITLE
Fix GDAL memory leaks and ProcessMetadata loop bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.9)
 
 project(richdem
-  VERSION 2.2.11
+  VERSION 2.2.12
   DESCRIPTION "High-performance terrain analysis"
   LANGUAGES CXX
 )

--- a/include/richdem/common/Array2D.hpp
+++ b/include/richdem/common/Array2D.hpp
@@ -48,12 +48,12 @@ namespace richdem {
 
 template<typename> class Array3D;
 
-inline std::map<std::string, std::string> ProcessMetadata(char **metadata){
+inline std::map<std::string, std::string> ProcessMetadata(const char *const *metadata){
   std::map<std::string, std::string> ret;
-  if(metadata==NULL)
+  if(metadata==nullptr)
     return ret;
 
-  for(int metstri=0;metadata[metstri]==NULL;metstri++){
+  for(int metstri=0;metadata[metstri]!=nullptr;metstri++){
     std::string metstr = metadata[metstri];
     const auto equals  = metstr.find("=");
     if(equals==std::string::npos){
@@ -1152,6 +1152,7 @@ class Array2D {
     if(poDriver==NULL)
       throw std::runtime_error("Could not open GDAL driver!");
     GDALDataset *fout    = poDriver->Create(input_filename.c_str(), width(), height(), 1, myGDALType(), papszOptions);
+    CSLDestroy(papszOptions);
     if(fout==NULL)
       throw std::runtime_error("Could not open file '"+input_filename+"' for GDAL save!");
 

--- a/include/richdem/common/loaders.hpp
+++ b/include/richdem/common/loaders.hpp
@@ -106,6 +106,7 @@ void SaveGDAL(const Array2D<T> &arr, const std::string &filename, const std::str
   if(poDriver==NULL)
     throw std::runtime_error("Could not open GDAL driver!");
   GDALDataset *fout    = poDriver->Create(filename.c_str(), arr.width(), arr.height(), 1, NativeTypeToGDAL<T>(), papszOptions);
+  CSLDestroy(papszOptions);
   if(fout==NULL)
     throw std::runtime_error("Could not open file '"+filename+"' for GDAL save!");
 

--- a/include/richdem/common/version.hpp
+++ b/include/richdem/common/version.hpp
@@ -31,7 +31,7 @@ namespace richdem {
 #endif
 
 ///Richdem vX.X.X
-const std::string program_name = "RichDEM v2.2.9";
+const std::string program_name = "RichDEM v2.2.10";
 
 ///Richard Barnes
 const std::string author_name  = "Richard Barnes";

--- a/wrappers/pyrichdem/pyproject.toml
+++ b/wrappers/pyrichdem/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "richdem2"
-version = "2.2.0"
+version = "2.2.1"
 description = "High-Performance Terrain Analysis"
 readme = "README.md"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary
- Call `CSLDestroy` on `papszOptions` in both `SaveGDAL` paths to release the GDAL string list that was previously leaked.
- Fix `ProcessMetadata` so it advances while entries are non-null (the prior `==NULL` check exited immediately) and take a `const char *const *` to match GDAL's metadata API.
- Bump package versions for the next release.

## Test plan
- [ ] `cmake -S . -B build && cmake --build build` succeeds with no new warnings.
- [ ] Round-trip a GeoTIFF through `SaveGDAL` and confirm metadata is preserved.
- [ ] Build the Python wheel from `wrappers/pyrichdem` and import `richdem2`.