### PR TITLE
Fix MSVC M_PI build error and add Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     defaults:

--- a/include/richdem/common/constants.hpp
+++ b/include/richdem/common/constants.hpp
@@ -27,6 +27,12 @@
 #include <stdexcept>
 #include <string>
 
+// MSVC does not define M_PI by default. Provide a portable fallback so headers
+// that reference M_PI compile on every supported toolchain.
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
 namespace richdem {
 
 ///sqrt(2), used to generate distances from a central cell to its neighbours

--- a/include/richdem/flats/flat_resolution_dinf.hpp
+++ b/include/richdem/flats/flat_resolution_dinf.hpp
@@ -7,6 +7,7 @@
 
 #include <richdem/flats/flat_resolution.hpp>
 #include <richdem/flowmet/dinf_flowdirs.hpp>
+#include <richdem/common/constants.hpp>
 #include <richdem/common/logger.hpp>
 
 namespace richdem {

--- a/include/richdem/flowmet/dinf_flowdirs.hpp
+++ b/include/richdem/flowmet/dinf_flowdirs.hpp
@@ -10,6 +10,7 @@ described in Barnes (TODO).
 */
 #pragma once
 
+#include <richdem/common/constants.hpp>
 #include <richdem/common/logger.hpp>
 #include <richdem/common/Array2D.hpp>
 #include <richdem/common/ProgressBar.hpp>


### PR DESCRIPTION
## Summary
- Adds an `#ifndef M_PI` fallback in `include/richdem/common/constants.hpp` so MSVC, which does not define `M_PI` by default, compiles the headers that reference it (`dinf_flowdirs.hpp`, `flat_resolution_dinf.hpp`, `Tarboton1997.hpp`, `dinf_methods.hpp`, `terrain_attributes.hpp`).
- Pulls `constants.hpp` into the two affected headers that did not already include it (`dinf_flowdirs.hpp`, `flat_resolution_dinf.hpp`) so the fallback is visible regardless of include order or `_USE_MATH_DEFINES`.
- Extends the GitHub Actions CI matrix to `windows-latest` so MSVC regressions like #13 are caught before they reach the conda-forge feedstock.

Closes #13.

## Test plan
- [x] `cmake --build` of `richdem_unittests` succeeds locally on Linux (the target that was failing on Windows with `'M_PI': undeclared identifier`).
- [x] `pre-commit run --all-files` passes.
- [ ] GitHub Actions CI on `windows-latest` (Python 3.10–3.13) builds the `_richdem` extension and `pytest` passes.
- [ ] GitHub Actions CI on `ubuntu-latest` and `macos-latest` remain green.