### PR TITLE
Bump pyrichdem to 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+2026-05-18 (2.4.1)
+==================
+
+* Fix MSVC build: define `M_PI` fallback in `constants.hpp` so the D-infinity
+  and terrain-attribute headers compile under MSVC (#13, #14)
+* Add `windows-latest` to the GitHub Actions CI matrix to catch MSVC
+  regressions before they reach the conda-forge feedstock (#14)
+
+
 2026-05-11 (2.4.0)
 ==================
 

--- a/wrappers/pyrichdem/pyproject.toml
+++ b/wrappers/pyrichdem/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "richdem2"
-version = "2.4.0"
+version = "2.4.1"
 description = "High-Performance Terrain Analysis (maintained fork of RichDEM)"
 readme = "README.md"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary
- Bumps `wrappers/pyrichdem/pyproject.toml` version from `2.4.0` to `2.4.1`.
- Adds a `2.4.1` entry to `CHANGELOG.md` covering the MSVC `M_PI` fix and the new Windows CI matrix entry.

This is the release-cut companion to #14 — please merge that first so the published wheels include the Windows build fix for #13.

## Test plan
- [x] `pre-commit run --all-files` passes.
- [ ] After merge: tag `v2.4.1` to trigger `pypi.yml` and confirm wheels build for Linux, macOS, and Windows.