### PR TITLE
Bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -14,10 +14,10 @@ jobs:
         working-directory: wrappers/pyrichdem
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -28,7 +28,7 @@ jobs:
         run: python -m build --sdist
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sdist
           path: wrappers/pyrichdem/dist/*.tar.gz
@@ -41,16 +41,16 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3.1
+        uses: pypa/cibuildwheel@v3.4.1
         with:
           package-dir: wrappers/pyrichdem
           output-dir: wheelhouse
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.os }}
           path: wheelhouse/*.whl
@@ -64,13 +64,13 @@ jobs:
 
     steps:
       - name: Download sdist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: sdist
           path: dist
 
       - name: Download wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: wheels-*
           path: dist


### PR DESCRIPTION
## Summary
Brings every action reference in `.github/workflows/` up to the latest major version. Only `pypi.yml` needed changes — `ci.yml` was already on the latest `checkout`/`setup-python` majors.

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4 | **v6** |
| `actions/setup-python` | v5 | **v6** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/download-artifact` | v4 | **v8** |
| `pypa/cibuildwheel` | v3.3.1 | **v3.4.1** |
| `pypa/gh-action-pypi-publish` | `release/v1` | `release/v1` (publisher-recommended floating ref — left alone) |

The major bumps are non-breaking for our usage:
- `upload-artifact@v7` adds opt-in direct uploads via a new `archive:` parameter; existing `name`/`path` usage is unchanged.
- `download-artifact@v8` defaults `digest-mismatch` to `error` (stricter security) and skips unzip on non-zipped downloads; our `name`/`pattern`/`merge-multiple` usage is unchanged.

## Test plan
- [ ] CI on `ubuntu-latest`, `macos-latest`, `windows-latest` (Python 3.10–3.13) stays green.
- [ ] Next release tag triggers `pypi.yml` and successfully builds + uploads sdist + wheels.