### PR TITLE
Bump pyrichdem to 2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+2026-05-18 (2.4.2)
+==================
+
+* Guard OpenMP user-defined reductions for MSVC and add CMake-based CI so
+  configure-time regressions on Linux/macOS/Windows are caught early (#17)
+* Bump GitHub Actions (`checkout`, `setup-python`, `upload-artifact`,
+  `download-artifact`, `cibuildwheel`, `gh-action-pypi-publish`) to their
+  latest major versions (#16)
+
+
 2026-05-18 (2.4.1)
 ==================
 

--- a/wrappers/pyrichdem/pyproject.toml
+++ b/wrappers/pyrichdem/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "richdem2"
-version = "2.4.1"
+version = "2.4.2"
 description = "High-Performance Terrain Analysis (maintained fork of RichDEM)"
 readme = "README.md"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary
- Bumps `richdem2` from 2.4.1 to 2.4.2 in [wrappers/pyrichdem/pyproject.toml](wrappers/pyrichdem/pyproject.toml).
- Adds a 2.4.2 section to [CHANGELOG.md](CHANGELOG.md) covering the MSVC OpenMP reduction guard + CMake CI (#17) and the GitHub Actions major-version bumps (#16).

## Test plan
- [ ] CI passes on the PR (Linux/macOS/Windows CMake + cibuildwheel)
- [ ] After merge, tag `v2.4.2` to trigger the PyPI release workflow