### PR TITLE
Fix Windows unresolved symbols when building from source tarball

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+2026-05-19 (2.4.3)
+==================
+
+* Fix Windows link errors (`generate_perlin_terrain`, `uniform_rand_real`)
+  when conda-forge (or any consumer) builds from the GitHub source tarball.
+  The wrapper used to rely on a `lib/richdem` symlink for its `.cpp` glob;
+  the symlink does not survive tarball extraction on Windows, so `setup.py`
+  now resolves the richdem source tree relative to the wrapper directory
+  (preferring `../..` and falling back to `lib/richdem` for sdist installs)
+  (#19)
+
+
 2026-05-18 (2.4.2)
 ==================
 

--- a/wrappers/pyrichdem/pyproject.toml
+++ b/wrappers/pyrichdem/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "richdem2"
-version = "2.4.2"
+version = "2.4.3"
 description = "High-Performance Terrain Analysis (maintained fork of RichDEM)"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/wrappers/pyrichdem/setup.py
+++ b/wrappers/pyrichdem/setup.py
@@ -1,4 +1,5 @@
 import glob
+import os
 import re
 import subprocess
 from typing import Optional
@@ -9,6 +10,45 @@ from setuptools.command.build_ext import build_ext as _build_ext
 
 richdem_compile_time: Optional[str] = None
 richdem_git_hash: Optional[str] = None
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def find_richdem_source_root() -> str:
+    """Locate the richdem C++ source tree, relative to this setup.py.
+
+    Prefer the parent repository (``../..``) when this wrapper is built from
+    a full richdem2 checkout. The conda-forge Windows build extracts the
+    GitHub source tarball, where the ``lib/richdem`` symlink does not survive,
+    so the symlinked path can't be the only way in. Newer setuptools
+    versions also reject the symlinked path because it resolves to an
+    absolute path once dereferenced. Fall back to ``lib/richdem`` for sdist
+    installs: the PyPI tarball ships real copies of the headers and sources
+    under that directory and has no parent repo to walk up to.
+
+    Returns:
+        A path (relative to this setup.py) of a directory containing
+        ``include/richdem`` and ``src`` subtrees.
+
+    Raises:
+        RuntimeError: If neither candidate location contains the expected
+            ``include/richdem`` and ``src`` subdirectories.
+    """
+    candidates = [
+        os.path.join("..", ".."),
+        os.path.join("lib", "richdem"),
+    ]
+    for candidate in candidates:
+        absolute = os.path.join(HERE, candidate)
+        if os.path.isdir(
+            os.path.join(absolute, "include", "richdem")
+        ) and os.path.isdir(os.path.join(absolute, "src")):
+            return candidate
+    raise RuntimeError(
+        "Could not locate the richdem C++ source tree. Looked in: "
+        + ", ".join(candidates)
+    )
+
 
 # Compiler specific arguments
 BUILD_ARGS = {
@@ -73,14 +113,20 @@ if richdem_git_hash is None:
 
 print(f"Using RichDEM hash={richdem_git_hash}, time={richdem_compile_time}")
 
+richdem_root = find_richdem_source_root()
+
 ext_modules = [
     Pybind11Extension(
         "_richdem",
         sorted(
             ["src/pywrapper.cpp"]
-            + list(glob.glob("lib/richdem/src/**/*.cpp", recursive=True))
+            + list(
+                glob.glob(
+                    os.path.join(richdem_root, "src", "**", "*.cpp"), recursive=True
+                )
+            )
         ),
-        include_dirs=["lib/richdem/include"],
+        include_dirs=[os.path.join(richdem_root, "include")],
         define_macros=[
             ("DOCTEST_CONFIG_DISABLE", None),
             ("RICHDEM_COMPILE_TIME", f'"\\"{richdem_compile_time}\\""'),


### PR DESCRIPTION
Closes #19.

## Summary

- `wrappers/pyrichdem/setup.py` no longer requires the `lib/richdem` symlink to be a real directory. The richdem source tree is resolved relative to setup.py: `../..` is tried first (works for any full source checkout, including the conda-forge tarball case) and `lib/richdem` is used as a fallback for sdist installs.
- Bumps pyrichdem to 2.4.3 and documents the fix in CHANGELOG.md.

## Why the old build broke on Windows

The conda-forge feedstock builds from `https://github.com/giswqs/richdem2/archive/v{version}.tar.gz`, which preserves the `wrappers/pyrichdem/lib/richdem -> ../../../` symlink. On Windows the symlink doesn't survive tarball extraction (it ends up as a non-directory placeholder), so `glob.glob("lib/richdem/src/**/*.cpp", recursive=True)` returned `[]` and only `pywrapper.cpp` was compiled. Headers were still resolvable through `%LIBRARY_PREFIX%/include` (the recipe runs `nmake install` before `pip install`), which is why compilation succeeded but the linker complained about the two free functions actually referenced by `pywrapper.cpp`:

- `richdem::generate_perlin_terrain` - defined in `src/terrain_generation/terrain_generation.cpp`, called from `pywrapper.cpp:141`
- `richdem::uniform_rand_real` - defined in `src/random.cpp`, pulled in transitively via `include/richdem/flowmet/Fairfield1991.hpp`

Modern setuptools (>= 79) also rejects the symlinked layout because it resolves source paths through the symlink to absolute paths, which `setup()` refuses.

## Test plan

- [x] `pip install ./wrappers/pyrichdem` in a clean venv on Linux (uses the `../..` branch) - wheel builds and `richdem.generate_perlin_terrain(20, 42)` works
- [x] `python -m build --sdist ./wrappers/pyrichdem` produces an sdist that contains all five `.cpp` files under `lib/richdem/src/`
- [x] `pip install <sdist>.tar.gz` in a clean venv (uses the `lib/richdem` fallback branch) - wheel builds successfully
- [ ] CI matrix (ubuntu/macos/windows x py3.10-3.13) green
- [ ] conda-forge feedstock rebuild on Windows succeeds against the resulting v2.4.3 tag